### PR TITLE
Remove .env and add dev.secret.exs for config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ npm-debug.log
 # Ignore environment variable files
 .env
 .env.ps1
+/config/*.secret.exs
 
 # Ignore self-signed cert
 priv/cert/

--- a/CLA.md
+++ b/CLA.md
@@ -87,3 +87,4 @@ The undersigned have all agreed to this CLA:
 * Maria Mora (@riamaria)
 * Troy Coll (@tacohole)
 * Ava Collins (@simplesthing)
+* Emil Socks (@EmiSocks)

--- a/config/config.exs
+++ b/config/config.exs
@@ -54,8 +54,3 @@ config :stripity_stripe,
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"
-
-# Import local development config.
-if config_env() == :dev do
-  import_config "dev.secret.exs"
-end

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,17 +4,6 @@
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
 
-# Load environment variables
-if File.exists?(".env.ps1") and System.find_executable("powershell") do
-  IO.puts("Loading .env.ps1")
-  System.cmd("powershell", [".env.ps1"])
-end
-
-if File.exists?(".env") and System.find_executable("source") do
-  IO.puts("Loading .env")
-  System.cmd("source", [".env"])
-end
-
 # General application configuration
 import Config
 
@@ -65,3 +54,8 @@ config :stripity_stripe,
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"
+
+# Import local development config.
+if config_env() == :dev do
+  import_config "dev.secret.exs"
+end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,8 +1,7 @@
 import Config
 
 # Configure your database
-config :banchan, Banchan.Repo,
-  show_sensitive_data_on_connection_error: true
+config :banchan, Banchan.Repo, show_sensitive_data_on_connection_error: true
 
 # For development, we disable any cache and enable
 # debugging and code reloading.
@@ -11,6 +10,7 @@ config :banchan, Banchan.Repo,
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :banchan, BanchanWeb.Endpoint,
+  http: [port: 4000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
@@ -74,3 +74,6 @@ config :phoenix, :stacktrace_depth, 20
 
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
+
+# Import local development config
+import_config "dev.secret.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,12 +2,7 @@ import Config
 
 # Configure your database
 config :banchan, Banchan.Repo,
-  username: "postgres",
-  password: "postgres",
-  database: "banchan_dev",
-  hostname: "localhost",
-  show_sensitive_data_on_connection_error: true,
-  pool_size: 10
+  show_sensitive_data_on_connection_error: true
 
 # For development, we disable any cache and enable
 # debugging and code reloading.
@@ -16,7 +11,6 @@ config :banchan, Banchan.Repo,
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :banchan, BanchanWeb.Endpoint,
-  http: [port: 4000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/config/dev.secret.example.exs
+++ b/config/dev.secret.example.exs
@@ -1,0 +1,29 @@
+# This is an example file for what dev.secret.exs should look like.
+# Copy it and set the configuration as needed.
+
+import Config
+
+# Which port the server runs on
+config :banchan, BanchanWeb.Endpoint,
+  http: [port: 4000]
+
+# Database configuration
+config :banchan, Banchan.Repo,
+  username: "postgres",
+  password: "postgres",
+  database: "banchan_dev",
+  hostname: "localhost",
+  pool_size: 10
+
+# Stripe configuration
+config :stripity_stripe,
+  api_key: "",
+  endpoint_secret: ""
+
+# AWS configuration. If left unset,
+# uploads will be saved to priv/uploads
+#config :ex_aws,
+  #bucket: "",
+  #region: "us-west-1",
+  #access_key_id: "",
+  #secret_access_key: ""

--- a/config/dev.secret.example.exs
+++ b/config/dev.secret.example.exs
@@ -3,10 +3,6 @@
 
 import Config
 
-# Which port the server runs on
-config :banchan, BanchanWeb.Endpoint,
-  http: [port: 4000]
-
 # Database configuration
 config :banchan, Banchan.Repo,
   username: "postgres",
@@ -22,8 +18,8 @@ config :stripity_stripe,
 
 # AWS configuration. If left unset,
 # uploads will be saved to priv/uploads
-#config :ex_aws,
-  #bucket: "",
-  #region: "us-west-1",
-  #access_key_id: "",
-  #secret_access_key: ""
+# config :ex_aws,
+# bucket: "",
+# region: "us-west-1",
+# access_key_id: "",
+# secret_access_key: ""


### PR DESCRIPTION
Since the `.env` configuration file did not seem to be working, this instead adds an Elixir file for setting these variables. It contains the options that one might want to change locally but not commit: database stuff, Stripe, AWS and HTTP port. This should fix #199.

Since it's in `.gitignore`, I've included an example file instead, so the idea is that one would copy `dev.secret.example.exs` into `dev.secret.exs` and modify it. It's intentionally set up so that it fails to run if `dev.secret.exs` does not exist, so that people can't forget to do that, but it should probably be added to the wiki and replace the section about environment variables.

I have tested the variables for HTTP port, database connection and Stripe (at least that it runs and Stripe doesn't complain about it), but not that the AWS variables actually work. They should, but someone should test that.

Also, it only does that import for dev, which is the only environment that matters for this, I think. If the `.env` file was also used in test, maybe a `test.secret.exs` file would be needed too?