### PR TITLE
misc safety changes and features

### DIFF
--- a/lib/banchan/accounts/accounts.ex
+++ b/lib/banchan/accounts/accounts.ex
@@ -341,6 +341,14 @@ defmodule Banchan.Accounts do
   end
 
   @doc """
+  Updates admin-level fields for a user, such as their roles.
+  """
+  def update_admin_fields(%User{} = actor, %User{} = user, attrs \\ %{}) do
+    User.admin_changeset(actor, user, attrs)
+    |> Repo.update()
+  end
+
+  @doc """
   Updates the user profile fields.
 
   ## Examples

--- a/lib/banchan/accounts/accounts.ex
+++ b/lib/banchan/accounts/accounts.ex
@@ -452,8 +452,7 @@ defmodule Banchan.Accounts do
           Repo.update_all(
             from(h in DisableHistory,
               where: h.user_id == ^user.id,
-              select: h,
-              order_by: {:desc, :disabled_at}
+              select: h
             ),
             set: [
               lifted_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),

--- a/lib/banchan/accounts/disable_history.ex
+++ b/lib/banchan/accounts/disable_history.ex
@@ -15,6 +15,7 @@ defmodule Banchan.Accounts.DisableHistory do
     field :disabled_reason, :string
     field :lifted_reason, :string
     field :lifted_at, :naive_datetime
+    belongs_to :lifted_by, User, on_replace: :nilify
   end
 
   def disable_changeset(history, attrs) do

--- a/lib/banchan/accounts/disable_history.ex
+++ b/lib/banchan/accounts/disable_history.ex
@@ -1,0 +1,49 @@
+defmodule Banchan.Accounts.DisableHistory do
+  @moduledoc """
+  Historical data for disabled users.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Banchan.Accounts.User
+
+  schema "disable_history" do
+    belongs_to :user, User, on_replace: :nilify
+    belongs_to :disabled_by, User, on_replace: :nilify
+    field :disabled_at, :naive_datetime
+    field :disabled_until, :naive_datetime
+    field :disabled_reason, :string
+    field :lifted_reason, :string
+    field :lifted_at, :naive_datetime
+  end
+
+  def disable_changeset(history, attrs) do
+    changeset =
+      history
+      |> cast(attrs, [
+        :disabled_until,
+        :disabled_reason
+      ])
+      |> put_change(:disabled_at, NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second))
+      |> validate_required([:disabled_reason])
+      |> validate_length(:disabled_reason, max: 500)
+
+    changeset
+    |> validate_change(:disabled_until, fn field, until ->
+      if NaiveDateTime.compare(
+           Ecto.Changeset.get_field(changeset, :disabled_at, NaiveDateTime.utc_now()),
+           until
+         ) != :lt do
+        [{field, "Disabled-until time must be after the time when the user was disabled."}]
+      else
+        []
+      end
+    end)
+  end
+
+  def enable_changeset(history, attrs) do
+    history
+    |> cast(attrs, [:lifted_reason])
+    |> validate_length(:lifted_reason, max: 500)
+  end
+end

--- a/lib/banchan/accounts/notifications.ex
+++ b/lib/banchan/accounts/notifications.ex
@@ -14,7 +14,7 @@ defmodule Banchan.Accounts.Notifications do
     |> Repo.exists?()
   end
 
-  def follow_user!(%User{} = target, %User{} = user) do
+  def follow_user!(%User{} = target, %User{} = user) when target.id != user.id do
     %UserFollower{user_id: user.id, target_id: target.id}
     |> Repo.insert(on_conflict: :nothing, conflict_target: [:user_id, :target_id])
 

--- a/lib/banchan/accounts/user.ex
+++ b/lib/banchan/accounts/user.ex
@@ -17,7 +17,7 @@ defmodule Banchan.Accounts.User do
     field :confirmed_at, :naive_datetime
     field :name, :string
     field :bio, :string
-    field :roles, {:array, Ecto.Enum}, values: [:admin, :mod, :creator]
+    field :roles, {:array, Ecto.Enum}, values: [:admin, :mod, :artist]
     field :totp_secret, :binary
     field :totp_activated, :boolean
     field :tags, {:array, :string}
@@ -207,7 +207,6 @@ defmodule Banchan.Accounts.User do
 
     user
     |> cast(attrs, [
-      :handle,
       :name,
       :bio,
       :tags,
@@ -227,8 +226,6 @@ defmodule Banchan.Accounts.User do
       :tiktok_handle,
       :artfight_handle
     ])
-    |> validate_required([:handle])
-    |> validate_handle()
     |> validate_name()
     |> validate_bio()
     |> validate_tags()

--- a/lib/banchan/offerings/offering.ex
+++ b/lib/banchan/offerings/offering.ex
@@ -5,6 +5,8 @@ defmodule Banchan.Offerings.Offering do
   use Ecto.Schema
   import Ecto.Changeset
 
+  import Banchan.Validators
+
   alias Banchan.Commissions.Commission
   alias Banchan.Offerings.{GalleryImage, OfferingOption}
   alias Banchan.Studios.Studio
@@ -66,15 +68,5 @@ defmodule Banchan.Offerings.Offering do
     |> validate_length(:template, max: 1500)
     |> validate_required([:type, :name, :description])
     |> unique_constraint([:type, :studio_id])
-  end
-
-  defp validate_markdown(changeset, field) do
-    validate_change(changeset, field, fn _, data ->
-      if data == HtmlSanitizeEx.markdown_html(data) do
-        []
-      else
-        [{field, "Disallowed HTML detected. Some tags, like <script>, are not allowed."}]
-      end
-    end)
   end
 end

--- a/lib/banchan/studios/studio.ex
+++ b/lib/banchan/studios/studio.ex
@@ -4,6 +4,8 @@ defmodule Banchan.Studios.Studio do
   use Ecto.Schema
   import Ecto.Changeset
 
+  import Banchan.Validators
+
   alias Banchan.Identities
   alias Banchan.Studios.{Common, PortfolioImage}
   alias Banchan.Uploads.Upload
@@ -121,44 +123,6 @@ defmodule Banchan.Studios.Studio do
         []
       else
         [{current_field, "already exists"}]
-      end
-    end)
-  end
-
-  defp validate_markdown(changeset, field) do
-    validate_change(changeset, field, fn _, data ->
-      if data == HtmlSanitizeEx.markdown_html(data) do
-        []
-      else
-        [{field, "Disallowed HTML detected. Some tags, like <script>, are not allowed."}]
-      end
-    end)
-  end
-
-  def validate_tags(changeset) do
-    changeset
-    |> validate_change(:tags, fn field, tags ->
-      if tags |> Enum.map(&String.downcase/1) ==
-           tags |> Enum.map(&String.downcase/1) |> Enum.uniq() do
-        []
-      else
-        [{field, "cannot have duplicate tags."}]
-      end
-    end)
-    |> validate_change(:tags, fn field, tags ->
-      if Enum.count(tags) > 10 do
-        [{field, "cannot have more than 10 tags."}]
-      else
-        []
-      end
-    end)
-    |> validate_change(:tags, fn field, tags ->
-      if Enum.all?(tags, fn tag ->
-           String.match?(tag, ~r/^.{0,100}$/)
-         end) do
-        []
-      else
-        [{field, "Tags can only be up to 100 characters long."}]
       end
     end)
   end

--- a/lib/banchan/validators.ex
+++ b/lib/banchan/validators.ex
@@ -1,0 +1,45 @@
+defmodule Banchan.Validators do
+  @moduledoc """
+  Shared validators.
+  """
+  import Ecto.Changeset
+
+  def validate_markdown(changeset, field) do
+    validate_change(changeset, field, fn _, data ->
+      if data == HtmlSanitizeEx.markdown_html(data) do
+        []
+      else
+        [{field, "Disallowed HTML detected. Some tags, like <script>, are not allowed."}]
+      end
+    end)
+  end
+
+  # :tags is hardcoded because the trigger expects the column to be called :tags
+  def validate_tags(changeset) do
+    changeset
+    |> validate_change(:tags, fn field, tags ->
+      if tags |> Enum.map(&String.downcase/1) ==
+           tags |> Enum.map(&String.downcase/1) |> Enum.uniq() do
+        []
+      else
+        [{field, "cannot have duplicate tags."}]
+      end
+    end)
+    |> validate_change(:tags, fn field, tags ->
+      if Enum.count(tags) > 10 do
+        [{field, "cannot have more than 10 tags."}]
+      else
+        []
+      end
+    end)
+    |> validate_change(:tags, fn field, tags ->
+      if Enum.all?(tags, fn tag ->
+           String.match?(tag, ~r/^.{0,100}$/)
+         end) do
+        []
+      else
+        [{field, "Tags can only be up to 100 characters long."}]
+      end
+    end)
+  end
+end

--- a/lib/banchan_web/components/form/date_time_local_input.ex
+++ b/lib/banchan_web/components/form/date_time_local_input.ex
@@ -1,10 +1,10 @@
-defmodule BanchanWeb.Components.Form.MultipleSelect do
+defmodule BanchanWeb.Components.Form.DateTimeLocalInput do
   @moduledoc """
   Banchan-specific TextInput.
   """
   use BanchanWeb, :component
 
-  alias Surface.Components.Form.{ErrorTag, Field, Label, MultipleSelect}
+  alias Surface.Components.Form.{DateTimeLocalInput, ErrorTag, Field, Label}
   alias Surface.Components.Form.Input.InputContext
 
   prop name, :any, required: true
@@ -12,9 +12,8 @@ defmodule BanchanWeb.Components.Form.MultipleSelect do
   prop class, :css_class
   prop label, :string
   prop show_label, :boolean, default: true
-  prop icon, :string
   prop info, :string
-  prop options, :any, default: []
+  prop icon, :string
 
   def render(assigns) do
     ~F"""
@@ -42,21 +41,20 @@ defmodule BanchanWeb.Components.Form.MultipleSelect do
           {/if}
           <div class="control w-full">
             <InputContext :let={form: form, field: field}>
-              <MultipleSelect
+              <DateTimeLocalInput
                 class={
-                  "textarea",
-                  "textarea-bordered",
+                  "input",
+                  "input-bordered",
                   "w-full",
                   @class,
-                  "textarea-error": !Enum.empty?(Keyword.get_values(form.errors, field))
+                  "input-error": !Enum.empty?(Keyword.get_values(form.errors, field))
                 }
                 opts={@opts}
-                options={@options}
               />
             </InputContext>
           </div>
         </div>
-        <ErrorTag class="text-error" />
+        <ErrorTag class="help text-error" />
       </div>
     </Field>
     """

--- a/lib/banchan_web/components/form/multiple_select.ex
+++ b/lib/banchan_web/components/form/multiple_select.ex
@@ -55,8 +55,8 @@ defmodule BanchanWeb.Components.Form.MultipleSelect do
               />
             </InputContext>
           </div>
-          <ErrorTag class="help is-danger" />
         </div>
+          <ErrorTag class="text-error" />
       </div>
     </Field>
     """

--- a/lib/banchan_web/controllers/user_auth.ex
+++ b/lib/banchan_web/controllers/user_auth.ex
@@ -8,6 +8,7 @@ defmodule BanchanWeb.UserAuth do
   plug Ueberauth
 
   alias Banchan.Accounts
+  alias Banchan.Repo
   alias BanchanWeb.Endpoint
   alias BanchanWeb.Router.Helpers, as: Routes
 
@@ -105,7 +106,7 @@ defmodule BanchanWeb.UserAuth do
   def fetch_current_user(conn, _opts) do
     {user_token, conn} = ensure_user_token(conn)
     user = user_token && Accounts.get_user_by_session_token(user_token)
-    assign(conn, :current_user, user)
+    assign(conn, :current_user, user |> Repo.preload(:disable_info))
   end
 
   defp ensure_user_token(conn) do

--- a/lib/banchan_web/live/auth_live/account_disabled_live.ex
+++ b/lib/banchan_web/live/auth_live/account_disabled_live.ex
@@ -10,8 +10,13 @@ defmodule BanchanWeb.AccountDisabledLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok,
-     socket |> assign(current_user: socket.assigns.current_user |> Repo.preload(:disable_info))}
+    user = socket.assigns.current_user && Repo.preload(socket.assigns.current_user, :disable_info)
+
+    if is_nil(user) || is_nil(user.disable_info) do
+      {:ok, socket |> push_redirect(to: Routes.login_path(Endpoint, :new))}
+    else
+      {:ok, socket |> assign(current_user: user)}
+    end
   end
 
   @impl true

--- a/lib/banchan_web/live/auth_live/account_disabled_live.ex
+++ b/lib/banchan_web/live/auth_live/account_disabled_live.ex
@@ -1,0 +1,49 @@
+defmodule BanchanWeb.AccountDisabledLive do
+  @moduledoc """
+  Page shown to disabled users.
+  """
+  use BanchanWeb, :surface_view
+
+  alias Banchan.Repo
+
+  alias BanchanWeb.Components.{Layout, Markdown}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket |> assign(current_user: socket.assigns.current_user |> Repo.preload(:disable_info))}
+  end
+
+  @impl true
+  def handle_params(_params, uri, socket) do
+    {:noreply, socket |> assign(uri: uri)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~F"""
+    <Layout uri={@uri} padding={0} current_user={@current_user} flashes={@flash}>
+      <div class="w-full h-full md:bg-base-300">
+        <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
+          <div class="text-xl">
+            Account Disabled
+          </div>
+          <div :if={@current_user.disable_info.disabled_until}>
+            Your account has been disabled until {@current_user.disabled_until |> Timex.to_datetime() |> Timex.format!("{RFC822}")}.
+          </div>
+          <div :if={is_nil(@current_user.disable_info.disabled_until)}>
+            Your account has been indefinitely disabled.
+          </div>
+          <div :if={@current_user.disable_info.disabled_reason}>
+            <div class="divider" />
+            <div class="text-xl">
+              Reason
+            </div>
+            <Markdown content={@current_user.disable_info.disabled_reason} />
+          </div>
+        </div>
+      </div>
+    </Layout>
+    """
+  end
+end

--- a/lib/banchan_web/live/auth_live/settings_live.ex
+++ b/lib/banchan_web/live/auth_live/settings_live.ex
@@ -86,14 +86,14 @@ defmodule BanchanWeb.SettingsLive do
            val["change_handle"]["password"],
            val["change_handle"]
          ) do
-      {:ok, updated_user} ->
+      {:ok, _updated_user} ->
         socket =
           socket
           |> put_flash(
             :info,
-            "Your handle has been updated."
+            "Your handle has been updated. Please log in again."
           )
-          |> push_redirect(to: Routes.denizen_show_path(Endpoint, :show, updated_user.handle))
+          |> push_redirect(to: Routes.login_path(Endpoint, :new))
 
         {:noreply, socket}
 

--- a/lib/banchan_web/live/auth_live/settings_live.ex
+++ b/lib/banchan_web/live/auth_live/settings_live.ex
@@ -309,25 +309,25 @@ defmodule BanchanWeb.SettingsLive do
           <Submit class="w-full" changeset={@new_email_changeset} label="Save" />
         </Form>
       {#else}
-      <Form
-        class="flex flex-col gap-4"
-        as={:change_handle}
-        for={@handle_changeset}
-        change="change_handle"
-        submit="submit_handle"
-        opts={autocomplete: "off"}
-      >
-        <h3 class="text-lg font-medium">
-          Update Handle
-        </h3>
-        <TextInput name={:handle} icon="at" opts={required: true} />
-        <TextInput name={:password} icon="lock" opts={required: true, type: :password} />
-        <LiveRedirect class="link link-primary" to={Routes.forgot_password_path(Endpoint, :edit)}>
-          Forgot your password?
-        </LiveRedirect>
-        <Submit class="w-full" changeset={@handle_changeset} label="Save" />
-      </Form>
-      <div class="divider" />
+        <Form
+          class="flex flex-col gap-4"
+          as={:change_handle}
+          for={@handle_changeset}
+          change="change_handle"
+          submit="submit_handle"
+          opts={autocomplete: "off"}
+        >
+          <h3 class="text-lg font-medium">
+            Update Handle
+          </h3>
+          <TextInput name={:handle} icon="at" opts={required: true} />
+          <TextInput name={:password} icon="lock" opts={required: true, type: :password} />
+          <LiveRedirect class="link link-primary" to={Routes.forgot_password_path(Endpoint, :edit)}>
+            Forgot your password?
+          </LiveRedirect>
+          <Submit class="w-full" changeset={@handle_changeset} label="Save" />
+        </Form>
+        <div class="divider" />
         <Form
           class="flex flex-col gap-4"
           as={:change_email}

--- a/lib/banchan_web/live/auth_live/settings_live.ex
+++ b/lib/banchan_web/live/auth_live/settings_live.ex
@@ -376,6 +376,9 @@ defmodule BanchanWeb.SettingsLive do
             label="New Password Confirmation"
             opts={required: true, type: :password}
           />
+          <LiveRedirect class="link link-primary" to={Routes.forgot_password_path(Endpoint, :edit)}>
+            Forgot your password?
+          </LiveRedirect>
           <Submit class="w-full" changeset={@password_changeset} label="Save" />
         </Form>
       {/if}

--- a/lib/banchan_web/live/denizen_live/admin_edit.ex
+++ b/lib/banchan_web/live/denizen_live/admin_edit.ex
@@ -7,23 +7,45 @@ defmodule BanchanWeb.DenizenLive.AdminEdit do
   alias Surface.Components.Form
 
   alias Banchan.Accounts
+  alias Banchan.Accounts.{DisableHistory, User}
+  alias Banchan.Repo
 
-  alias BanchanWeb.Components.Form.{Submit, MarkdownInput, MultipleSelect}
+  alias BanchanWeb.Components.Form.{
+    DateTimeLocalInput,
+    MarkdownInput,
+    MultipleSelect,
+    Submit,
+    TextInput
+  }
+
   alias BanchanWeb.Components.Layout
   alias BanchanWeb.Endpoint
 
   @impl true
   def mount(%{"handle" => handle}, _session, socket) do
     if :admin in socket.assigns.current_user.roles || :mod in socket.assigns.current_user.roles do
-      user = Accounts.get_user_by_handle!(handle)
+      user =
+        Accounts.get_user_by_handle!(handle)
+        |> Repo.preload(:disable_info)
 
-      {:ok,
-       socket
-       |> assign(
-         user: user,
-         roles: [Mod: :mod, Admin: :admin, Artist: :artist],
-         changeset: User.admin_changeset(socket.assigns.current_user, user)
-       )}
+      socket =
+        socket
+        |> assign(
+          user: user,
+          roles: [Mod: :mod, Admin: :admin, Artist: :artist],
+          changeset: User.admin_changeset(socket.assigns.current_user, user)
+        )
+
+      socket =
+        if user.disable_info do
+          socket
+          |> assign(enable_changeset: DisableHistory.enable_changeset(%DisableHistory{}, %{}))
+        else
+          socket
+          |> assign(disable_changeset: DisableHistory.disable_changeset(%DisableHistory{}, %{}))
+        end
+
+      {:ok, socket}
     else
       {:ok,
        socket
@@ -49,14 +71,79 @@ defmodule BanchanWeb.DenizenLive.AdminEdit do
 
   @impl true
   def handle_event("submit", val, socket) do
-    case Accounts.update_admin_fields(socket.assigns.current_user, socket.assigns.user, val["user"]) do
+    case Accounts.update_admin_fields(
+           socket.assigns.current_user,
+           socket.assigns.user,
+           val["user"]
+         ) do
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, socket |> assign(changeset: changeset)}
+
       {:ok, user} ->
         {:noreply,
-        socket
-        |> put_flash(:info, "User updated.")
-        |> push_redirect(to: Routes.denizen_show_path(Endpoint, :show, user.handle))}
+         socket
+         |> put_flash(:info, "User updated.")
+         |> push_redirect(to: Routes.denizen_show_path(Endpoint, :show, user.handle))}
+    end
+  end
+
+  @impl true
+  def handle_event("change_disable", val, socket) do
+    changeset =
+      %DisableHistory{}
+      |> DisableHistory.disable_changeset(val["disable"])
+      |> Map.put(:action, :update)
+
+    {:noreply, socket |> assign(disable_changeset: changeset)}
+  end
+
+  @impl true
+  def handle_event("submit_disable", val, socket) do
+    case Accounts.disable_user(
+           socket.assigns.current_user,
+           socket.assigns.user,
+           val["disable"]
+         ) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "User disabled.")
+         |> push_redirect(
+           to: Routes.denizen_show_path(Endpoint, :show, socket.assigns.user.handle)
+         )}
+
+      {:error, changeset} ->
+        {:noreply, socket |> assign(disable_changeset: changeset)}
+    end
+  end
+
+  @impl true
+  def handle_event("change_enable", val, socket) do
+    changeset =
+      %DisableHistory{}
+      |> DisableHistory.enable_changeset(val["disable"])
+      |> Map.put(:action, :update)
+
+    {:noreply, socket |> assign(enable_changeset: changeset)}
+  end
+
+  @impl true
+  def handle_event("submit_enable", val, socket) do
+    case Accounts.enable_user(
+           socket.assigns.current_user,
+           socket.assigns.user,
+           val["enable"]
+         ) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "User enabled.")
+         |> push_redirect(
+           to: Routes.denizen_show_path(Endpoint, :show, socket.assigns.user.handle)
+         )}
+
+      {:error, changeset} ->
+        {:noreply, socket |> assign(enable_changeset: changeset)}
     end
   end
 
@@ -66,14 +153,41 @@ defmodule BanchanWeb.DenizenLive.AdminEdit do
     <Layout uri={@uri} padding={0} current_user={@current_user} flashes={@flash}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
-          <Form class="profile-info" for={@changeset} change="change" submit="submit">
+          <Form as={:user} for={@changeset} change="change" submit="submit">
             <div class="text-xl">
               Manage User @{@user.handle}
             </div>
-            <MultipleSelect info="User roles to apply to this user. Can select multiple items." name={:roles} options={@roles} />
-            <MarkdownInput id="moderation_notes" info="These are internal notes for admins and moderators about this user. They are not displayed to the user or anyone else." name={:moderation_notes} />
+            <MultipleSelect
+              info="User roles to apply to this user. Can select multiple items."
+              name={:roles}
+              options={@roles}
+            />
+            <MarkdownInput
+              id="moderation_notes"
+              info="These are internal notes for admins and moderators about this user. They are not displayed to the user or anyone else."
+              name={:moderation_notes}
+            />
             <Submit label="Save" changeset={@changeset} />
           </Form>
+          <div class="divider" />
+          {#if @user.disable_info}
+            <Form as={:enable} for={@enable_changeset} change="change_enable" submit="submit_enable">
+              <div class="text-xl">
+                Re-enable @{@user.handle}
+              </div>
+              <TextInput name={:lifted_reason} opts={required: true} />
+              <Submit label="Enable" changeset={@enable_changeset} />
+            </Form>
+          {#else}
+            <Form as={:disable} for={@disable_changeset} change="change_disable" submit="submit_disable">
+              <div class="text-xl">
+                Disable @{@user.handle}
+              </div>
+              <TextInput name={:disabled_reason} opts={required: true} />
+              <DateTimeLocalInput name={:disabled_until} />
+              <Submit label="Disable" changeset={@disable_changeset} />
+            </Form>
+          {/if}
         </div>
       </div>
     </Layout>

--- a/lib/banchan_web/live/denizen_live/admin_edit.ex
+++ b/lib/banchan_web/live/denizen_live/admin_edit.ex
@@ -1,0 +1,82 @@
+defmodule BanchanWeb.DenizenLive.AdminEdit do
+  @moduledoc """
+  Admin-level user editing, such as changing roles, disabling, and such.
+  """
+  use BanchanWeb, :surface_view
+
+  alias Surface.Components.Form
+
+  alias Banchan.Accounts
+
+  alias BanchanWeb.Components.Form.{Submit, MarkdownInput, MultipleSelect}
+  alias BanchanWeb.Components.Layout
+  alias BanchanWeb.Endpoint
+
+  @impl true
+  def mount(%{"handle" => handle}, _session, socket) do
+    if :admin in socket.assigns.current_user.roles || :mod in socket.assigns.current_user.roles do
+      user = Accounts.get_user_by_handle!(handle)
+
+      {:ok,
+       socket
+       |> assign(
+         user: user,
+         roles: [Mod: :mod, Admin: :admin, Artist: :artist],
+         changeset: User.admin_changeset(socket.assigns.current_user, user)
+       )}
+    else
+      {:ok,
+       socket
+       |> put_flash(:error, "You are not authorized to access this page.")
+       |> push_redirect(to: Routes.denizen_show_path(Endpoint, :show, handle))}
+    end
+  end
+
+  @impl true
+  def handle_params(_params, uri, socket) do
+    {:noreply, socket |> assign(uri: uri)}
+  end
+
+  @impl true
+  def handle_event("change", val, socket) do
+    changeset =
+      socket.assigns.user
+      |> User.admin_changeset(socket.assigns.current_user, val["user"])
+      |> Map.put(:action, :update)
+
+    {:noreply, socket |> assign(changeset: changeset)}
+  end
+
+  @impl true
+  def handle_event("submit", val, socket) do
+    case Accounts.update_admin_fields(socket.assigns.current_user, socket.assigns.user, val["user"]) do
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, socket |> assign(changeset: changeset)}
+      {:ok, user} ->
+        {:noreply,
+        socket
+        |> put_flash(:info, "User updated.")
+        |> push_redirect(to: Routes.denizen_show_path(Endpoint, :show, user.handle))}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~F"""
+    <Layout uri={@uri} padding={0} current_user={@current_user} flashes={@flash}>
+      <div class="w-full md:bg-base-300">
+        <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
+          <Form class="profile-info" for={@changeset} change="change" submit="submit">
+            <div class="text-xl">
+              Manage User @{@user.handle}
+            </div>
+            <MultipleSelect info="User roles to apply to this user. Can select multiple items." name={:roles} options={@roles} />
+            <MarkdownInput id="moderation_notes" info="These are internal notes for admins and moderators about this user. They are not displayed to the user or anyone else." name={:moderation_notes} />
+            <Submit label="Save" changeset={@changeset} />
+          </Form>
+        </div>
+      </div>
+    </Layout>
+    """
+  end
+end

--- a/lib/banchan_web/live/denizen_live/admin_edit.ex
+++ b/lib/banchan_web/live/denizen_live/admin_edit.ex
@@ -23,11 +23,12 @@ defmodule BanchanWeb.DenizenLive.AdminEdit do
 
   @impl true
   def mount(%{"handle" => handle}, _session, socket) do
-    if :admin in socket.assigns.current_user.roles || :mod in socket.assigns.current_user.roles do
-      user =
-        Accounts.get_user_by_handle!(handle)
-        |> Repo.preload(:disable_info)
+    user =
+      Accounts.get_user_by_handle!(handle)
+      |> Repo.preload(:disable_info)
 
+    if :admin in socket.assigns.current_user.roles ||
+         (:mod in socket.assigns.current_user.roles && :admin not in user.roles) do
       socket =
         socket
         |> assign(

--- a/lib/banchan_web/live/denizen_live/admin_edit.ex
+++ b/lib/banchan_web/live/denizen_live/admin_edit.ex
@@ -14,8 +14,7 @@ defmodule BanchanWeb.DenizenLive.AdminEdit do
     DateTimeLocalInput,
     MarkdownInput,
     MultipleSelect,
-    Submit,
-    TextInput
+    Submit
   }
 
   alias BanchanWeb.Components.Layout
@@ -122,7 +121,7 @@ defmodule BanchanWeb.DenizenLive.AdminEdit do
   def handle_event("change_enable", val, socket) do
     changeset =
       %DisableHistory{}
-      |> DisableHistory.enable_changeset(val["disable"])
+      |> DisableHistory.enable_changeset(val["enable"])
       |> Map.put(:action, :update)
 
     {:noreply, socket |> assign(enable_changeset: changeset)}
@@ -176,7 +175,7 @@ defmodule BanchanWeb.DenizenLive.AdminEdit do
               <div class="text-xl">
                 Re-enable @{@user.handle}
               </div>
-              <TextInput name={:lifted_reason} opts={required: true} />
+              <MarkdownInput id="lifted_reason" name={:lifted_reason} opts={required: true} />
               <Submit label="Enable" changeset={@enable_changeset} />
             </Form>
           {#else}
@@ -184,7 +183,7 @@ defmodule BanchanWeb.DenizenLive.AdminEdit do
               <div class="text-xl">
                 Disable @{@user.handle}
               </div>
-              <TextInput name={:disabled_reason} opts={required: true} />
+              <MarkdownInput id="disabled_reason" name={:disabled_reason} opts={required: true} />
               <DateTimeLocalInput name={:disabled_until} />
               <Submit label="Disable" changeset={@disable_changeset} />
             </Form>

--- a/lib/banchan_web/live/denizen_live/show.ex
+++ b/lib/banchan_web/live/denizen_live/show.ex
@@ -95,6 +95,13 @@ defmodule BanchanWeb.DenizenLive.Show do
               <span>@{@user.handle}</span>
             </div>
             <div class="flex flex-row gap-2 place-content-end ml-auto m-4">
+              {#if @current_user && (:admin in @current_user.roles || :mod in @current_user.roles)}
+                <LiveRedirect
+                  label="Moderation"
+                  to={Routes.denizen_admin_edit_path(Endpoint, :edit, @user.handle)}
+                  class="btn btn-sm btn-warning btn-outline rounded-full m-2 px-2 py-0 grow-0"
+                />
+              {/if}
               {#if @current_user &&
                   (@current_user.id == @user.id || :admin in @current_user.roles || :mod in @current_user.roles)}
                 <LiveRedirect

--- a/lib/banchan_web/live/denizen_live/show.ex
+++ b/lib/banchan_web/live/denizen_live/show.ex
@@ -94,21 +94,25 @@ defmodule BanchanWeb.DenizenLive.Show do
               </h1>
               <span>@{@user.handle}</span>
             </div>
-            {#if @current_user && @current_user.id == @user.id}
-              <LiveRedirect
-                label="Edit Profile"
-                to={Routes.denizen_edit_path(Endpoint, :edit, @user.handle)}
-                class="btn btn-sm btn-primary btn-outline m-4 ml-auto rounded-full px-2 py-0"
-              />
-            {#else}
-              <Button click="toggle_follow" class="btn-sm btn-outline m-4 ml-auto rounded-full px-2 py-0">
-                {if @user_following? do
-                  "Unfollow"
-                else
-                  "Follow"
-                end}
-              </Button>
-            {/if}
+            <div class="flex flex-row gap-2 place-content-end ml-auto m-4">
+              {#if @current_user &&
+                  (@current_user.id == @user.id || :admin in @current_user.roles || :mod in @current_user.roles)}
+                <LiveRedirect
+                  label="Edit Profile"
+                  to={Routes.denizen_edit_path(Endpoint, :edit, @user.handle)}
+                  class="btn btn-sm btn-primary btn-outline rounded-full m-2 px-2 py-0 grow-0"
+                />
+              {/if}
+              {#if @current_user && @current_user.id != @user.id}
+                <Button click="toggle_follow" class="btn-sm btn-outline m-2 rounded-full px-2 py-0 grow-0">
+                  {if @user_following? do
+                    "Unfollow"
+                  else
+                    "Follow"
+                  end}
+                </Button>
+              {/if}
+            </div>
           </div>
           <div class="mx-6 my-4">
             {@user.bio}

--- a/lib/banchan_web/live/denizen_live/show.ex
+++ b/lib/banchan_web/live/denizen_live/show.ex
@@ -98,7 +98,7 @@ defmodule BanchanWeb.DenizenLive.Show do
               {#if @current_user && (:admin in @current_user.roles || :mod in @current_user.roles)}
                 <LiveRedirect
                   label="Moderation"
-                  to={Routes.denizen_admin_edit_path(Endpoint, :edit, @user.handle)}
+                  to={Routes.denizen_moderation_path(Endpoint, :edit, @user.handle)}
                   class="btn btn-sm btn-warning btn-outline rounded-full m-2 px-2 py-0 grow-0"
                 />
               {/if}

--- a/lib/banchan_web/live/studio_live/studio_live_helpers.ex
+++ b/lib/banchan_web/live/studio_live/studio_live_helpers.ex
@@ -30,7 +30,8 @@ defmodule BanchanWeb.StudioLive.Helpers do
     Studios.Notifications.subscribe_to_follower_count(studio)
 
     cond do
-      current_member && !current_user_member? ->
+      current_member && !current_user_member? && :admin not in socket.assigns.current_user.roles &&
+          :mod not in socket.assigns.current_user.roles ->
         raise Ecto.NoResultsError, queryable: from(u in User, join: s in assoc(u, :studios))
 
       requires_stripe && !Studios.charges_enabled?(studio, false) ->

--- a/lib/banchan_web/live/user_live_auth.ex
+++ b/lib/banchan_web/live/user_live_auth.ex
@@ -27,9 +27,15 @@ defmodule BanchanWeb.UserLiveAuth do
         :admins_only ->
           !is_nil(socket.assigns.current_user) && :admin in socket.assigns.current_user.roles
 
+        :mods_only ->
+          !is_nil(socket.assigns.current_user) &&
+            (:mod in socket.assigns.current_user.roles ||
+               :admin in socket.assigns.current_user.roles)
+
         :artists_only ->
           !is_nil(socket.assigns.current_user) &&
             (:artist in socket.assigns.current_user.roles ||
+               :mod in socket.assigns.current_user.roles ||
                :admin in socket.assigns.current_user.roles)
       end
 

--- a/lib/banchan_web/live/user_live_auth.ex
+++ b/lib/banchan_web/live/user_live_auth.ex
@@ -16,16 +16,33 @@ defmodule BanchanWeb.UserLiveAuth do
         find_current_user(session)
       end)
 
-    if auth == :users_only || (auth == :admins_only && is_nil(socket.assigns.current_user)) do
-      {:halt,
-       socket
-       |> put_flash(:error, "You must log in to access this page.")
-       |> redirect(to: Routes.user_session_path(socket, :create))}
-    else
+    allowed =
+      case auth do
+        :default ->
+          true
+
+        :users_only ->
+          !is_nil(socket.assigns.current_user)
+
+        :admins_only ->
+          !is_nil(socket.assigns.current_user) && :admin in socket.assigns.current_user.roles
+
+        :artists_only ->
+          !is_nil(socket.assigns.current_user) &&
+            (:artist in socket.assigns.current_user.roles ||
+               :admin in socket.assigns.current_user.roles)
+      end
+
+    if allowed do
       # This is important so clients get booted when they log out elsewhere.
       Accounts.subscribe_to_auth_events()
 
       {:cont, socket}
+    else
+      {:halt,
+       socket
+       |> put_flash(:error, "You do not have access to this page.")
+       |> redirect(to: Routes.user_session_path(socket, :create))}
     end
   end
 

--- a/lib/banchan_web/live/user_live_auth.ex
+++ b/lib/banchan_web/live/user_live_auth.ex
@@ -10,6 +10,7 @@ defmodule BanchanWeb.UserLiveAuth do
 
   alias BanchanWeb.Router.Helpers, as: Routes
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def on_mount(auth, _params, session, socket) do
     socket =
       socket
@@ -29,6 +30,9 @@ defmodule BanchanWeb.UserLiveAuth do
             true
 
           :open ->
+            true
+
+          :redirect_if_authed ->
             true
 
           :users_only ->

--- a/lib/banchan_web/live/user_live_auth.ex
+++ b/lib/banchan_web/live/user_live_auth.ex
@@ -41,10 +41,12 @@ defmodule BanchanWeb.UserLiveAuth do
               :admin in socket.assigns.current_user.roles
 
           :mods_only ->
-            !is_nil(socket.assigns.current_user &&
-              is_nil(socket.assigns.current_user.disable_info) &&
-              (:mod in socket.assigns.current_user.roles ||
-                 :admin in socket.assigns.current_user.roles))
+            !is_nil(
+              socket.assigns.current_user &&
+                is_nil(socket.assigns.current_user.disable_info) &&
+                (:mod in socket.assigns.current_user.roles ||
+                   :admin in socket.assigns.current_user.roles)
+            )
 
           :artists_only ->
             !is_nil(socket.assigns.current_user) &&

--- a/lib/banchan_web/plugs/ensure_enabled_plug.ex
+++ b/lib/banchan_web/plugs/ensure_enabled_plug.ex
@@ -1,0 +1,58 @@
+defmodule BanchanWeb.EnsureEnabledPlug do
+  @moduledoc """
+  Ensures that only users that aren't disabled (with the `disabled_at` field)
+  can access a given route.
+  """
+  import Plug.Conn
+
+  alias Phoenix.Controller
+
+  alias Banchan.Accounts
+  alias Banchan.Repo
+
+  alias BanchanWeb.Endpoint
+  alias BanchanWeb.Router.Helpers, as: Routes
+
+  @doc false
+  @spec init(any()) :: any()
+  def init(config), do: config
+
+  @doc false
+  def call(conn, _) do
+    user_token = get_session(conn, :user_token)
+
+    user =
+      user_token && Accounts.get_user_by_session_token(user_token) |> Repo.preload(:disable_info)
+
+    if is_nil(user) do
+      maybe_halt(false, conn)
+    else
+      user
+      |> enabled?()
+      |> maybe_halt(conn)
+    end
+  end
+
+  defp enabled?(user) when is_nil(user.disable_info), do: true
+  defp enabled?(user) when is_nil(user.disable_info.disabled_until), do: false
+
+  defp enabled?(user) do
+    if NaiveDateTime.compare(NaiveDateTime.utc_now(), user.disable_info.disabled_until) == :gt do
+      {:ok, _} = Accounts.enable_user(nil, user, "Disabled time frame expired.")
+      true
+    else
+      false
+    end
+  end
+
+  defp maybe_halt(true, conn), do: conn
+
+  defp maybe_halt(_any, conn) do
+    conn
+    |> Controller.put_flash(:error, "You are not authorized to access this page.")
+    |> Controller.redirect(to: disabled_path(conn))
+    |> halt()
+  end
+
+  defp disabled_path(_conn), do: Routes.account_disabled_path(Endpoint, :show)
+end

--- a/lib/banchan_web/plugs/ensure_role_plug.ex
+++ b/lib/banchan_web/plugs/ensure_role_plug.ex
@@ -45,7 +45,7 @@ defmodule BanchanWeb.EnsureRolePlug do
 
   defp maybe_halt(_any, conn) do
     conn
-    |> Controller.put_flash(:error, "Unauthorised")
+    |> Controller.put_flash(:error, "You are not authorized to perform this action.")
     |> Controller.redirect(to: signed_in_path(conn))
     |> halt()
   end

--- a/lib/banchan_web/router.ex
+++ b/lib/banchan_web/router.ex
@@ -46,8 +46,8 @@ defmodule BanchanWeb.Router do
     plug(EnsureRolePlug, [:admin, :mod])
   end
 
-  pipeline :creator do
-    plug(EnsureRolePlug, [:admin, :mod, :creator])
+  pipeline :artist do
+    plug(EnsureRolePlug, [:admin, :mod, :artist])
   end
 
   scope "/", BanchanWeb do
@@ -56,14 +56,7 @@ defmodule BanchanWeb.Router do
 
       live("/denizens/:handle/edit", DenizenLive.Edit, :edit)
 
-      live("/studios/new", StudioLive.New, :new)
-      live("/studios/:handle/settings", StudioLive.Settings, :show)
-      live("/studios/:handle/payouts", StudioLive.Payouts, :index)
-      live("/studios/:handle/payouts/:payout_id", StudioLive.Payouts, :show)
-      live("/studios/:handle/offerings/new", StudioLive.Offerings.New, :new)
-      live("/studios/:handle/offerings/edit/:offering_type", StudioLive.Offerings.Edit, :edit)
       live("/studios/:handle/commissions/new/:offering_type", StudioLive.Commissions.New, :new)
-      get("/studios/:handle/settings/stripe", StripeDashboardController, :dashboard)
 
       live("/commissions", CommissionLive, :index)
       live("/commissions/:commission_id", CommissionLive, :show)
@@ -85,6 +78,21 @@ defmodule BanchanWeb.Router do
 
       get("/settings/confirm_email/:token", UserSettingsController, :confirm_email)
       get("/settings/refresh_session/:return_to", UserSessionController, :refresh_session)
+    end
+  end
+
+  scope "/", BanchanWeb do
+    live_session :artists_only, on_mount: BanchanWeb.UserLiveAuth do
+      pipe_through([:browser, :require_authenticated_user, :artist])
+
+      live("/studios/new", StudioLive.New, :new)
+      live("/studios/:handle/settings", StudioLive.Settings, :show)
+      live("/studios/:handle/payouts", StudioLive.Payouts, :index)
+      live("/studios/:handle/payouts/:payout_id", StudioLive.Payouts, :show)
+      live("/studios/:handle/offerings/new", StudioLive.Offerings.New, :new)
+      live("/studios/:handle/offerings/edit/:offering_type", StudioLive.Offerings.Edit, :edit)
+
+      get("/studios/:handle/settings/stripe", StripeDashboardController, :dashboard)
     end
   end
 

--- a/lib/banchan_web/router.ex
+++ b/lib/banchan_web/router.ex
@@ -56,7 +56,7 @@ defmodule BanchanWeb.Router do
   end
 
   scope "/", BanchanWeb do
-    live_session :users_only, on_mount: BanchanWeb.UserLiveAuth do
+    live_session :users_only, on_mount: {BanchanWeb.UserLiveAuth, :users_only} do
       pipe_through([:browser, :enabled_user])
 
       live("/denizens/:handle/edit", DenizenLive.Edit, :edit)
@@ -87,7 +87,7 @@ defmodule BanchanWeb.Router do
   end
 
   scope "/", BanchanWeb do
-    live_session :artists_only, on_mount: BanchanWeb.UserLiveAuth do
+    live_session :artists_only, on_mount: {BanchanWeb.UserLiveAuth, :artists_only} do
       pipe_through([:browser, :enabled_user, :artist])
 
       live("/studios/new", StudioLive.New, :new)
@@ -102,7 +102,7 @@ defmodule BanchanWeb.Router do
   end
 
   scope "/", BanchanWeb do
-    live_session :mods_only, on_mount: BanchanWeb.UserLiveAuth do
+    live_session :mods_only, on_mount: {BanchanWeb.UserLiveAuth, :mods_only} do
       pipe_through([:browser, :enabled_user, :mod])
 
       live("/denizens/:handle/admin_edit", DenizenLive.AdminEdit, :edit)
@@ -125,7 +125,7 @@ defmodule BanchanWeb.Router do
   end
 
   scope "/", BanchanWeb do
-    live_session :open, on_mount: BanchanWeb.UserLiveAuth do
+    live_session :open, on_mount: {BanchanWeb.UserLiveAuth, :open} do
       pipe_through(:browser)
 
       live("/", HomeLive, :index)
@@ -147,7 +147,7 @@ defmodule BanchanWeb.Router do
   end
 
   scope "/", BanchanWeb do
-    live_session :redirect_if_authed, on_mount: BanchanWeb.UserLiveAuth do
+    live_session :redirect_if_authed, on_mount: {BanchanWeb.UserLiveAuth, :redirect_if_authed} do
       pipe_through([:browser, :redirect_if_user_is_authenticated])
 
       live("/login", LoginLive, :new)

--- a/lib/banchan_web/router.ex
+++ b/lib/banchan_web/router.ex
@@ -97,6 +97,14 @@ defmodule BanchanWeb.Router do
   end
 
   scope "/", BanchanWeb do
+    live_session :mods_only, on_mount: BanchanWeb.UserLiveAuth do
+      pipe_through([:browser, :require_authenticated_user, :mod])
+
+      live("/denizens/:handle/admin_edit", DenizenLive.AdminEdit, :edit)
+    end
+  end
+
+  scope "/", BanchanWeb do
     pipe_through(:browser)
 
     get("/go/:handle", DispatchController, :dispatch)

--- a/lib/banchan_web/router.ex
+++ b/lib/banchan_web/router.ex
@@ -105,7 +105,7 @@ defmodule BanchanWeb.Router do
     live_session :mods_only, on_mount: {BanchanWeb.UserLiveAuth, :mods_only} do
       pipe_through([:browser, :enabled_user, :mod])
 
-      live("/denizens/:handle/admin_edit", DenizenLive.AdminEdit, :edit)
+      live("/denizens/:handle/moderation", DenizenLive.Moderation, :edit)
     end
   end
 

--- a/priv/repo/migrations/20210621000815_create_users_auth_tables.exs
+++ b/priv/repo/migrations/20210621000815_create_users_auth_tables.exs
@@ -18,18 +18,38 @@ defmodule Banchan.Repo.Migrations.CreateUsersAuthTables do
     create unique_index(:uploads, [:bucket, :key])
 
     create table(:users) do
+      # Identity/Auth
       add :handle, :citext, null: false
       add :email, :citext
       add :hashed_password, :string, null: false
       add :confirmed_at, :naive_datetime
-      add :roles, {:array, :string}, default: [], null: false
-      add :name, :string
-      add :bio, :string
       add :totp_secret, :binary
       add :totp_activated, :boolean
+
+      # OAuth
       add :twitter_uid, :text
       add :google_uid, :text
       add :discord_uid, :text
+
+      # Perms and Moderation
+      add :roles, {:array, :string}, default: [], null: false
+      add :moderation_notes, :text
+      add :disabled_reason, :text
+      add :disabled_at, :naive_datetime
+      add :disabled_until, :naive_datetime
+      add :disabled_by_id, references(:users, on_delete: :nilify_all)
+
+      # Profile
+      add :name, :string
+      add :bio, :string
+      # Array fields are the best/fastest approach in most cases.
+      # http://www.databasesoup.com/2015/01/tag-all-things.html
+      add :tags, {:array, :citext}, default: [], null: false
+      add :header_img_id, references(:uploads, on_delete: :nilify_all, type: :uuid)
+      add :pfp_img_id, references(:uploads, on_delete: :nilify_all, type: :uuid)
+      add :pfp_thumb_id, references(:uploads, on_delete: :nilify_all, type: :uuid)
+
+      # Social Media
       add :twitter_handle, :text
       add :instagram_handle, :text
       add :facebook_url, :text
@@ -46,12 +66,6 @@ defmodule Banchan.Repo.Migrations.CreateUsersAuthTables do
       add :tiktok_handle, :text
       add :artfight_handle, :text
 
-      # Array fields are the best/fastest approach in most cases.
-      # http://www.databasesoup.com/2015/01/tag-all-things.html
-      add :tags, {:array, :citext}, default: [], null: false
-      add :header_img_id, references(:uploads, on_delete: :nilify_all, type: :uuid)
-      add :pfp_img_id, references(:uploads, on_delete: :nilify_all, type: :uuid)
-      add :pfp_thumb_id, references(:uploads, on_delete: :nilify_all, type: :uuid)
       timestamps()
     end
 

--- a/priv/repo/migrations/20210621000815_create_users_auth_tables.exs
+++ b/priv/repo/migrations/20210621000815_create_users_auth_tables.exs
@@ -155,6 +155,7 @@ defmodule Banchan.Repo.Migrations.CreateUsersAuthTables do
       add :disabled_at, :naive_datetime
       add :disabled_until, :naive_datetime
       add :disabled_reason, :text
+      add :lifted_by_id, references(:users, on_delete: :delete_all)
       add :lifted_reason, :text
       add :lifted_at, :naive_datetime
     end

--- a/priv/repo/migrations/20210621000815_create_users_auth_tables.exs
+++ b/priv/repo/migrations/20210621000815_create_users_auth_tables.exs
@@ -34,10 +34,6 @@ defmodule Banchan.Repo.Migrations.CreateUsersAuthTables do
       # Perms and Moderation
       add :roles, {:array, :string}, default: [], null: false
       add :moderation_notes, :text
-      add :disabled_reason, :text
-      add :disabled_at, :naive_datetime
-      add :disabled_until, :naive_datetime
-      add :disabled_by_id, references(:users, on_delete: :nilify_all)
 
       # Profile
       add :name, :string
@@ -152,5 +148,17 @@ defmodule Banchan.Repo.Migrations.CreateUsersAuthTables do
 
     create index(:users_tokens, [:user_id])
     create unique_index(:users_tokens, [:context, :token])
+
+    create table(:disable_history) do
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :disabled_by_id, references(:users, on_delete: :delete_all)
+      add :disabled_at, :naive_datetime
+      add :disabled_until, :naive_datetime
+      add :disabled_reason, :text
+      add :lifted_reason, :text
+      add :lifted_at, :naive_datetime
+    end
+
+    create index(:disable_history, [:user_id])
   end
 end

--- a/test/banchan/accounts_test.exs
+++ b/test/banchan/accounts_test.exs
@@ -373,6 +373,7 @@ defmodule Banchan.AccountsTest do
       {:error, changeset} =
         Accounts.update_user_profile(
           user,
+          user,
           %{
             handle: "12",
             name: String.duplicate("b", 40),
@@ -392,6 +393,7 @@ defmodule Banchan.AccountsTest do
     test "updates the user profile", %{user: user} do
       {:ok, user} =
         Accounts.update_user_profile(
+          user,
           user,
           %{
             handle: "newhandle",

--- a/test/banchan/accounts_test.exs
+++ b/test/banchan/accounts_test.exs
@@ -375,7 +375,6 @@ defmodule Banchan.AccountsTest do
           user,
           user,
           %{
-            handle: "12",
             name: String.duplicate("b", 40),
             bio: String.duplicate("a", 461)
           },
@@ -385,7 +384,6 @@ defmodule Banchan.AccountsTest do
 
       assert %{
                bio: ["should be at most 160 character(s)"],
-               handle: ["should be at least 3 character(s)"],
                name: ["should be at most 32 character(s)"]
              } = errors_on(changeset)
     end

--- a/test/banchan_web/live/denizen_live/edit_test.exs
+++ b/test/banchan_web/live/denizen_live/edit_test.exs
@@ -27,6 +27,7 @@ defmodule BanchanWeb.DenizenLive.EditTest do
       {:ok, user} =
         Accounts.update_user_profile(
           user,
+          user,
           %{
             name: "Name",
             bio: "Bio"
@@ -91,17 +92,14 @@ defmodule BanchanWeb.DenizenLive.EditTest do
         |> element(".profile-info")
         |> render_change(%{
           user: %{
-            handle: "bad handle",
             bio: String.duplicate("a", 500),
             name: String.duplicate("b", 50)
           }
         })
 
-      assert rendered =~ "bad handle"
       assert rendered =~ "aaaaaaaaaaa"
       assert rendered =~ "bbbbbbbbbbb"
 
-      assert rendered =~ "only letters, numbers, and underscores allowed"
       assert rendered =~ "should be at most 160 character(s)"
       assert rendered =~ "should be at most 32 character(s)"
     end
@@ -118,14 +116,16 @@ defmodule BanchanWeb.DenizenLive.EditTest do
         user: %{handle: "newhandle", bio: "new bio", name: "new name", email: "new@email"}
       })
 
-      assert_redirected(page_live, Routes.denizen_show_path(conn, :show, "newhandle"))
+      assert_redirected(page_live, Routes.denizen_show_path(conn, :show, user.handle))
 
       db_user = Accounts.get_user!(user.id)
 
       assert db_user.name == "new name"
       assert db_user.bio == "new bio"
-      assert db_user.handle == "newhandle"
+
+      # Handle and email cannot be updated through here.
       assert db_user.email == user.email
+      assert db_user.handle == user.handle
     end
   end
 end

--- a/test/banchan_web/live/denizen_live/edit_test.exs
+++ b/test/banchan_web/live/denizen_live/edit_test.exs
@@ -23,6 +23,13 @@ defmodule BanchanWeb.DenizenLive.EditTest do
       assert info.to =~ Routes.login_path(conn, :new)
     end
 
+    test "redirects if logged in as a different non-admin user", %{conn: conn, user: user} do
+      conn = log_in_user(conn, user_fixture())
+      {:error, {:live_redirect, info}} = live(conn, Routes.denizen_edit_path(conn, :edit, user.handle))
+
+      assert info.to =~ Routes.denizen_show_path(conn, :show, user.handle)
+    end
+
     test "preloads current profile values", %{conn: conn, user: user} do
       {:ok, user} =
         Accounts.update_user_profile(
@@ -106,6 +113,54 @@ defmodule BanchanWeb.DenizenLive.EditTest do
 
     test "updates profile values on submit, updates user in db", %{conn: conn, user: user} do
       conn = conn |> log_in_user(user)
+
+      {:ok, page_live, _disconnected_html} =
+        live(conn, Routes.denizen_edit_path(conn, :edit, user.handle))
+
+      page_live
+      |> element(".profile-info")
+      |> render_submit(%{
+        user: %{handle: "newhandle", bio: "new bio", name: "new name", email: "new@email"}
+      })
+
+      assert_redirected(page_live, Routes.denizen_show_path(conn, :show, user.handle))
+
+      db_user = Accounts.get_user!(user.id)
+
+      assert db_user.name == "new name"
+      assert db_user.bio == "new bio"
+
+      # Handle and email cannot be updated through here.
+      assert db_user.email == user.email
+      assert db_user.handle == user.handle
+    end
+
+    test "admins can edit profiles", %{conn: conn, user: user} do
+      conn = conn |> log_in_user(user_fixture(%{roles: [:admin]}))
+
+      {:ok, page_live, _disconnected_html} =
+        live(conn, Routes.denizen_edit_path(conn, :edit, user.handle))
+
+      page_live
+      |> element(".profile-info")
+      |> render_submit(%{
+        user: %{handle: "newhandle", bio: "new bio", name: "new name", email: "new@email"}
+      })
+
+      assert_redirected(page_live, Routes.denizen_show_path(conn, :show, user.handle))
+
+      db_user = Accounts.get_user!(user.id)
+
+      assert db_user.name == "new name"
+      assert db_user.bio == "new bio"
+
+      # Handle and email cannot be updated through here.
+      assert db_user.email == user.email
+      assert db_user.handle == user.handle
+    end
+
+    test "mods can edit profiles", %{conn: conn, user: user} do
+      conn = conn |> log_in_user(user_fixture(%{roles: [:mod]}))
 
       {:ok, page_live, _disconnected_html} =
         live(conn, Routes.denizen_edit_path(conn, :edit, user.handle))

--- a/test/banchan_web/live/denizen_live/edit_test.exs
+++ b/test/banchan_web/live/denizen_live/edit_test.exs
@@ -25,7 +25,9 @@ defmodule BanchanWeb.DenizenLive.EditTest do
 
     test "redirects if logged in as a different non-admin user", %{conn: conn, user: user} do
       conn = log_in_user(conn, user_fixture())
-      {:error, {:live_redirect, info}} = live(conn, Routes.denizen_edit_path(conn, :edit, user.handle))
+
+      {:error, {:live_redirect, info}} =
+        live(conn, Routes.denizen_edit_path(conn, :edit, user.handle))
 
       assert info.to =~ Routes.denizen_show_path(conn, :show, user.handle)
     end

--- a/test/banchan_web/live/denizen_live/show_test.exs
+++ b/test/banchan_web/live/denizen_live/show_test.exs
@@ -21,6 +21,7 @@ defmodule BanchanWeb.DenizenLive.ShowTest do
       {:ok, user} =
         Banchan.Accounts.update_user_profile(
           user,
+          user,
           %{bio: "This is my bio", name: "New User"},
           nil,
           nil

--- a/test/banchan_web/live/denizen_live/show_test.exs
+++ b/test/banchan_web/live/denizen_live/show_test.exs
@@ -56,7 +56,6 @@ defmodule BanchanWeb.DenizenLive.ShowTest do
       refute html =~ ~r/>\s+Follow\s+</
     end
 
-
     test "displays edit profile button for self, admins, and mods only", %{conn: conn, user: user} do
       stranger_conn = log_in_user(conn, user_fixture())
       admin_conn = log_in_user(conn, user_fixture(%{roles: [:admin]}))

--- a/test/banchan_web/live/denizen_live/show_test.exs
+++ b/test/banchan_web/live/denizen_live/show_test.exs
@@ -41,5 +41,64 @@ defmodule BanchanWeb.DenizenLive.ShowTest do
       assert disconnected_html =~ user.name
       assert rendered_html =~ user.name
     end
+
+    test "displays follow button for other logged in users only", %{conn: conn, user: user} do
+      stranger_conn = log_in_user(conn, user_fixture())
+      self_conn = log_in_user(conn, user)
+
+      {:ok, _, html} = live(conn, Routes.denizen_show_path(conn, :show, user.handle))
+      refute html =~ ~r/>\s+Follow\s+</
+
+      {:ok, _, html} = live(stranger_conn, Routes.denizen_show_path(conn, :show, user.handle))
+      assert html =~ ~r/>\s+Follow\s+</
+
+      {:ok, _, html} = live(self_conn, Routes.denizen_show_path(conn, :show, user.handle))
+      refute html =~ ~r/>\s+Follow\s+</
+    end
+
+
+    test "displays edit profile button for self, admins, and mods only", %{conn: conn, user: user} do
+      stranger_conn = log_in_user(conn, user_fixture())
+      admin_conn = log_in_user(conn, user_fixture(%{roles: [:admin]}))
+      mod_conn = log_in_user(conn, user_fixture(%{roles: [:mod]}))
+      self_conn = log_in_user(conn, user)
+
+      {:ok, _, html} = live(conn, Routes.denizen_show_path(conn, :show, user.handle))
+      refute html =~ "Edit Profile"
+
+      {:ok, _, html} = live(stranger_conn, Routes.denizen_show_path(conn, :show, user.handle))
+      refute html =~ "Edit Profile"
+
+      {:ok, _, html} = live(self_conn, Routes.denizen_show_path(conn, :show, user.handle))
+      assert html =~ "Edit Profile"
+
+      {:ok, _, html} = live(mod_conn, Routes.denizen_show_path(conn, :show, user.handle))
+      assert html =~ "Edit Profile"
+
+      {:ok, _, html} = live(admin_conn, Routes.denizen_show_path(conn, :show, user.handle))
+      assert html =~ "Edit Profile"
+    end
+
+    test "displays moderation button for admins and mods only", %{conn: conn, user: user} do
+      stranger_conn = log_in_user(conn, user_fixture())
+      admin_conn = log_in_user(conn, user_fixture(%{roles: [:admin]}))
+      mod_conn = log_in_user(conn, user_fixture(%{roles: [:mod]}))
+      self_conn = log_in_user(conn, user)
+
+      {:ok, _, html} = live(conn, Routes.denizen_show_path(conn, :show, user.handle))
+      refute html =~ "Moderation"
+
+      {:ok, _, html} = live(stranger_conn, Routes.denizen_show_path(conn, :show, user.handle))
+      refute html =~ "Moderation"
+
+      {:ok, _, html} = live(self_conn, Routes.denizen_show_path(conn, :show, user.handle))
+      refute html =~ "Moderation"
+
+      {:ok, _, html} = live(mod_conn, Routes.denizen_show_path(conn, :show, user.handle))
+      assert html =~ "Moderation"
+
+      {:ok, _, html} = live(admin_conn, Routes.denizen_show_path(conn, :show, user.handle))
+      assert html =~ "Moderation"
+    end
   end
 end

--- a/test/banchan_web/live/studio_live/payouts_test.exs
+++ b/test/banchan_web/live/studio_live/payouts_test.exs
@@ -80,12 +80,13 @@ defmodule BanchanWeb.StudioLive.PayoutsTest do
              |> render() =~ "This studio is not ready to accept commissions yet."
     end
 
-    test "404 if user is not a member", %{conn: conn, client: client, studio: studio} do
+    test "redirect if user is not a member", %{conn: conn, client: client, studio: studio} do
       conn = log_in_user(conn, client)
 
-      assert_raise Ecto.NoResultsError, fn ->
-        live(conn, Routes.studio_payouts_path(conn, :index, studio.handle))
-      end
+      assert {:error,
+              {:redirect,
+               %{flash: %{"error" => "You are not authorized to perform this action."}, to: "/"}}} ==
+               live(conn, Routes.studio_payouts_path(conn, :index, studio.handle))
     end
 
     test "can navigate to and from listing", %{

--- a/test/support/fixtures/commissions_fixtures.ex
+++ b/test/support/fixtures/commissions_fixtures.ex
@@ -19,7 +19,7 @@ defmodule Banchan.CommissionsFixtures do
   alias Banchan.Repo
 
   def commission_fixture(attrs \\ %{}) do
-    artist = Map.get(attrs, :artist) || user_fixture()
+    artist = Map.get(attrs, :artist) || user_fixture(%{roles: [:artist]})
     studio = Map.get(attrs, :studio) || studio_fixture([artist])
     offering = Map.get(attrs, :offering) || offering_fixture(studio)
 


### PR DESCRIPTION
* [x] Fix issue with users being able to edit each other's profiles
* [x] Move handle editing to user settings, for security
* [x] Allow admins and mods to edit user profiles
* [x] Add "moderation notes" for mods/admins to make remarks on users
* [x] Add ability to disable (and re-enable) users (aka bans)
* [x] Keep a history of moderation actions
* [x] Add plug for easily managing what pages users have access to
* [x] Do the same for UserLiveAuth
* [x] Show moderation action history in moderation page
* [x] Fix tests
* [x] Add additional tests for new security features/changes to make sure everything's cool